### PR TITLE
new layout for the RPC, and limit strings

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -125,6 +125,22 @@ async function searchAlbum(props: iTunesProps): Promise<iTunesInfos> {
   return infos;
 }
 
+/**
+ * limits string to specified number limit
+ * will output the string with 3 chars at the end replaced by '...'
+ * @param s string
+ * @param n char number limit
+ * @returns {string}
+ */
+function limitStr(s: string, n: number): string {
+  let l = s;
+  if (l.length > n) {
+    l = l.substring(0, n - 3) + "...";
+  }
+
+  return l;
+}
+
 // Activity setter
 
 async function setActivity(rpc: Client) {
@@ -137,6 +153,7 @@ async function setActivity(rpc: Client) {
 
     switch (state) {
       case "playing": {
+        // EVERYTHING must be less than or equal to 128 chars long
         const props = await getProps();
         console.log("props:", props);
 
@@ -145,15 +162,14 @@ async function setActivity(rpc: Client) {
 
         const delta = (props.duration - props.playerPosition) * 1000;
         const end = Math.ceil(Date.now() + delta);
-        const year = props.year ? ` (${props.year})` : "";
 
         const activity: Activity = {
-          details: props.name,
-          state: `${props.artist} — ${props.album}${year}`,
+          details: limitStr(props.name, 128),
+          state: limitStr(props.artist, 128),
           timestamps: { end },
           assets: {
             large_image: infos.artwork,
-            large_text: props.album,
+            large_text: limitStr(`${props.album} (${props.year})`, 128),
           },
         };
         if (infos.url) {

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -129,16 +129,11 @@ async function searchAlbum(props: iTunesProps): Promise<iTunesInfos> {
  * limits string to specified number limit
  * will output the string with 3 chars at the end replaced by '...'
  * @param s string
- * @param n char number limit
+ * @param maxLength char number limit
  * @returns {string}
  */
-function limitStr(s: string, n: number): string {
-  let l = s;
-  if (l.length > n) {
-    l = l.substring(0, n - 3) + "...";
-  }
-
-  return l;
+function limitStr(s: string, maxLength: number): string {
+  return s.length <= maxLength ? s : `${s.slice(0, maxLength - 3)}...`;
 }
 
 // Activity setter
@@ -153,7 +148,6 @@ async function setActivity(rpc: Client) {
 
     switch (state) {
       case "playing": {
-        // EVERYTHING must be less than or equal to 128 chars long
         const props = await getProps();
         console.log("props:", props);
 
@@ -163,13 +157,14 @@ async function setActivity(rpc: Client) {
         const delta = (props.duration - props.playerPosition) * 1000;
         const end = Math.ceil(Date.now() + delta);
 
+        // EVERYTHING must be less than or equal to 128 chars long
         const activity: Activity = {
           details: limitStr(props.name, 128),
           state: limitStr(props.artist, 128),
           timestamps: { end },
           assets: {
             large_image: infos.artwork,
-            large_text: `${limitStr(`${props.album}`, 120)} (${props.year})`,
+            large_text: limitStr(props.album, 128),
           },
         };
         if (infos.url) {

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -169,7 +169,7 @@ async function setActivity(rpc: Client) {
           timestamps: { end },
           assets: {
             large_image: infos.artwork,
-            large_text: limitStr(`${props.album} (${props.year})`, 128),
+            large_text: `${limitStr(`${props.album}`, 120)} (${props.year})`,
           },
         };
         if (infos.url) {


### PR DESCRIPTION
i think only `props.artist` should be in `activity.state` because i feel like it's cleaner that way, and not many people will pay attention to album title imo
the album title, `${props.album} (${props.year})` should be in `activity.assets.large_text` instead.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/49902829/168297226-a6276d72-234a-4f6c-a63d-aeb3dc001bce.png">
<img width="652" alt="image" src="https://user-images.githubusercontent.com/49902829/168297609-9bb73e8e-e530-4a32-a999-126dcf2a9ac7.png">

also, the state must be <= 128 characters.
so if the artists name/title is too long, like this:
![image](https://user-images.githubusercontent.com/49902829/168298684-94344e74-025f-4733-8f78-a4449adf0640.png)

it will throw this error and the status will not appear on discord.
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/49902829/168298393-ac0a4a7e-7af4-4d00-bd16-da28d82a54ce.png">

in this case only including the artist name works, but to be safe it's better to limit all to 128 characters
<img width="636" alt="image" src="https://user-images.githubusercontent.com/49902829/168298880-28412e4b-a62e-440f-8f62-17bb352bdc70.png">

thank you for this script btw its neat
