### PR TITLE
Fix incorrect album artwork being shown when the artist or album name contains an ampersand or other special characters

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -9,7 +9,7 @@ import type { iTunes } from "https://raw.githubusercontent.com/NextFire/jxa/64b6
 // Cache
 
 class Cache {
-  static VERSION = 2;
+  static VERSION = 3;
   static CACHE_FILE = "cache.json";
   static #data: Map<string, iTunesInfos> = new Map();
 

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -128,11 +128,20 @@ async function searchAlbum(props: iTunesProps): Promise<iTunesInfos> {
   let infos = Cache.get(query);
 
   if (!infos) {
-    const encodedQuery = encodeURI(decodeURI(query));
-    const resp = await fetch(
+    const encodedQuery = encodeURIComponent(decodeURIComponent(query));
+    const albumResp = await fetch(
       `https://itunes.apple.com/search?media=music&entity=album&limit=1&term=${encodedQuery}`
     );
-    const result = await resp.json();
+    const songResp = await fetch(
+      `https://itunes.apple.com/search?media=music&entity=song&limit=1&term=${encodedQuery}`
+    );
+    var result;
+    if (encodedQuery.indexOf('%26') > -1) {
+      result = await songResp.json();
+    }
+    else {
+      result = await albumResp.json();
+    }
 
     const artwork = result.results[0]?.artworkUrl100 ?? null;
     const url = result.results[0]?.collectionViewUrl ?? null;

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -135,11 +135,10 @@ async function searchAlbum(props: iTunesProps): Promise<iTunesInfos> {
     const songResp = await fetch(
       `https://itunes.apple.com/search?media=music&entity=song&limit=1&term=${encodedQuery}`
     );
-    var result;
-    if (encodedQuery.indexOf('%26') > -1) {
+    let result;
+    if (encodedQuery.indexOf("%26") > -1) {
       result = await songResp.json();
-    }
-    else {
+    } else {
       result = await albumResp.json();
     }
 

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -129,18 +129,11 @@ async function searchAlbum(props: iTunesProps): Promise<iTunesInfos> {
 
   if (!infos) {
     const encodedQuery = encodeURIComponent(decodeURIComponent(query));
-    const albumResp = await fetch(
-      `https://itunes.apple.com/search?media=music&entity=album&limit=1&term=${encodedQuery}`
+    const entity = encodedQuery.indexOf("%26") > -1 ? "song" : "album";
+    const resp = await fetch(
+      `https://itunes.apple.com/search?media=music&entity=${entity}&limit=1&term=${encodedQuery}`
     );
-    const songResp = await fetch(
-      `https://itunes.apple.com/search?media=music&entity=song&limit=1&term=${encodedQuery}`
-    );
-    let result;
-    if (encodedQuery.indexOf("%26") > -1) {
-      result = await songResp.json();
-    } else {
-      result = await albumResp.json();
-    }
+    const result = await resp.json();
 
     const artwork = result.results[0]?.artworkUrl100 ?? null;
     const url = result.results[0]?.collectionViewUrl ?? null;


### PR DESCRIPTION
I noticed that whenever an artist name or album name contained an ampersand, the query for the album artwork would return an incorrect result because the ampersand would cut off the rest of the query. I've fixed this by replacing ```encodeURI``` and ```decodeURI``` with ```encodeURIComponent``` and ```decodeURIComponent``` respectively. Furthermore, I have added a check that will see if the encoded query contains an encoded ampersand; if it does, then the iTunes Search API query will be adjusted to set the entity as a song rather than an album (otherwise the search would return no results :P).

Before:
![image](https://user-images.githubusercontent.com/9734245/178162181-8c9f505a-d3a2-41e6-9b16-da502ac84a29.png)
![image](https://user-images.githubusercontent.com/9734245/178162194-7a763d21-78b9-43a7-a762-81191e609af7.png)
![image](https://user-images.githubusercontent.com/9734245/178162201-2505cba8-8de9-4fe8-b019-9d77b80e4226.png)

After:
![image](https://user-images.githubusercontent.com/9734245/178162208-4d9b7c55-3fe3-43f7-9662-5d1eaf397454.png)
![image](https://user-images.githubusercontent.com/9734245/178162212-8433658e-8e6c-4061-9569-ff459add7181.png)
![image](https://user-images.githubusercontent.com/9734245/178162219-917877b6-a871-4f27-bb8e-35c8ec5d0aa4.png)
