### PR TITLE
Fetch correct album infos for albums that contain the artist name and/or have extra details in parentheses

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -142,7 +142,7 @@ async function searchAlbum(props: iTunesProps): Promise<iTunesInfos> {
     if (result.resultCount === 1) {
       result = result.results[0];
     } else if (result.resultCount > 1) { // If there are multiple results, find the right album
-      result = result.results.find((r) => r.collectionName === album_);
+      result = result.results.find((r: iTunesResult) => r.collectionName === album_);
     } else if (album_.match(/\(.*\)$/)) { // If there are no results, try to remove the part of the album name in parentheses (e.g. "Album (Deluxe Edition)")
       return getInfos(album_.replace(/\(.*\)$/, "").trim());
     }
@@ -244,6 +244,12 @@ async function setActivity(rpc: Client) {
 // TypeScript
 
 type iTunesAppName = "iTunes" | "Music";
+
+interface iTunesResult {
+  artworkUrl100: string;
+  collectionViewUrl: string;
+  collectionName: string;
+}
 
 interface iTunesProps {
   id: number;

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -2,7 +2,7 @@
 
 import type { Activity } from "https://raw.githubusercontent.com/harmonyland/discord_rpc/ba127c20816af15e2c3cd2c17d81248b097e9bd2/mod.ts";
 import { Client } from "https://raw.githubusercontent.com/harmonyland/discord_rpc/ba127c20816af15e2c3cd2c17d81248b097e9bd2/mod.ts";
-import type { } from "https://raw.githubusercontent.com/NextFire/jxa/64b6de1748ea063c01271edbe9846e37a584e1ab/run/global.d.ts";
+import type {} from "https://raw.githubusercontent.com/NextFire/jxa/64b6de1748ea063c01271edbe9846e37a584e1ab/run/global.d.ts";
 import { run } from "https://raw.githubusercontent.com/NextFire/jxa/64b6de1748ea063c01271edbe9846e37a584e1ab/run/mod.ts";
 import type { iTunes } from "https://raw.githubusercontent.com/NextFire/jxa/64b6de1748ea063c01271edbe9846e37a584e1ab/run/types/core.d.ts";
 

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -2,7 +2,7 @@
 
 import type { Activity } from "https://raw.githubusercontent.com/harmonyland/discord_rpc/ba127c20816af15e2c3cd2c17d81248b097e9bd2/mod.ts";
 import { Client } from "https://raw.githubusercontent.com/harmonyland/discord_rpc/ba127c20816af15e2c3cd2c17d81248b097e9bd2/mod.ts";
-import type {} from "https://raw.githubusercontent.com/NextFire/jxa/64b6de1748ea063c01271edbe9846e37a584e1ab/run/global.d.ts";
+import type { } from "https://raw.githubusercontent.com/NextFire/jxa/64b6de1748ea063c01271edbe9846e37a584e1ab/run/global.d.ts";
 import { run } from "https://raw.githubusercontent.com/NextFire/jxa/64b6de1748ea063c01271edbe9846e37a584e1ab/run/mod.ts";
 import type { iTunes } from "https://raw.githubusercontent.com/NextFire/jxa/64b6de1748ea063c01271edbe9846e37a584e1ab/run/types/core.d.ts";
 
@@ -129,16 +129,24 @@ async function searchAlbum(props: iTunesProps): Promise<iTunesInfos> {
 
   if (!infos) {
     const params = new URLSearchParams({
-      media: "music",
-      entity: "album",
-      limit: "1",
-      term: query,
+      ...{
+        media: "music",
+        entity: "album",
+        attribute: "albumTerm",
+        term: artist === album ? artist : query,
+      }, ...(artist === album ? {} : { limit: "1" })
     });
     const resp = await fetch(`https://itunes.apple.com/search?${params}`);
-    const result = await resp.json();
+    let result = await resp.json();
 
-    const artwork = result.results[0]?.artworkUrl100 ?? null;
-    const url = result.results[0]?.collectionViewUrl ?? null;
+    if (result.resultCount > 1) {
+      result = result.results.find((r) => r.collectionName === album);
+    } else {
+      result = result.results[0];
+    }
+
+    const artwork = result?.artworkUrl100 ?? null;
+    const url = result?.collectionViewUrl ?? null;
     infos = { artwork, url };
     Cache.set(query, infos);
   }


### PR DESCRIPTION
Currently, if you listen to an album with the same name as the artist (e.g. "Queens of the Stone Age" by "Queens of the Stone Age"), the album details that appear on your profile may be from a different album by the same band. I fixed this by fetching all the artist's albums if the album name contains the artist name, and then searching through the results to find the album which has the correct name.

If you listen to an album with extra details in parentheses (e.g. "Era Vulgaris (Bonus Track Version)" by "Queens of the Stone Age"), the album details may not be found. I fixed this by searching for the album without the part in parentheses if the initial search yields no results.