### PR TITLE
Modify Spotify search query string

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -206,7 +206,7 @@ async function setActivity(rpc: Client) {
         activity.state = formatStr(props.artist);
       }
 
-      const query = `${props.artist} ${props.name}`;
+      const query = `artist:${props.artist} track:${props.name}`;
       activity.buttons = [
         {
           label: "Search on Spotify",


### PR DESCRIPTION
I just modified the Spotify search query string so it matches the [API spec](https://developer.spotify.com/documentation/web-api/reference/search). This should return better results than the current implementation.