### PR TITLE
Increase album search accuracy

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -157,7 +157,16 @@ async function _searchAlbum(
     result = json.results[0];
   } else if (json.resultCount > 1) {
     // If there are multiple results, find the right album
-    result = json.results.find((r) => r.collectionName.includes(album));
+    // Use includes as imported songs may format it differently
+    // Also put them all to lowercase in case of differing capitalisation
+    result = json.results.find((r) =>
+      r.collectionName.toLowerCase().includes(album.toLowerCase()) &&
+      r.trackName.toLowerCase().includes(song.toLowerCase()) &&
+      // First split the artist's name for collabs
+      r.artistName.toLowerCase().split("&").every((rartist) =>
+        artist.toLowerCase().includes(rartist.trim())
+      )
+    );
   } else if (album.match(/\(.*\)$/)) {
     // If there are no results, try to remove the part
     // of the album name in parentheses (e.g. "Album (Deluxe Edition)")
@@ -283,6 +292,8 @@ interface iTunesSearchResponse {
 
 interface iTunesSearchResult {
   artworkUrl100: string;
+  artistName: string;
+  trackName: string;
   collectionViewUrl: string;
   collectionName: string;
 }

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -161,11 +161,7 @@ async function _searchAlbum(
     // Also put them all to lowercase in case of differing capitalisation
     result = json.results.find((r) =>
       r.collectionName.toLowerCase().includes(album.toLowerCase()) &&
-      r.trackName.toLowerCase().includes(song.toLowerCase()) &&
-      // First split the artist's name for collabs
-      r.artistName.toLowerCase().split("&").every((rartist) =>
-        artist.toLowerCase().includes(rartist.trim())
-      )
+      r.trackName.toLowerCase().includes(song.toLowerCase())
     );
   } else if (album.match(/\(.*\)$/)) {
     // If there are no results, try to remove the part
@@ -292,7 +288,6 @@ interface iTunesSearchResponse {
 
 interface iTunesSearchResult {
   artworkUrl100: string;
-  artistName: string;
   trackName: string;
   collectionViewUrl: string;
   collectionName: string;


### PR DESCRIPTION
Increases the accuracy of finding the correct song and therefore album art. This is done by including the song name into the search query and changing the `entity` to `song`. Also when searching through the returned result, it will also check the artist to further prevent false finds. This pull request also fixes searches where the song/artist/album includes an asterisk, in which iTunes will not return a result. It appears that removing the asterisks from the query string works, but it should probably be tested more. This may fix #46, #56.