### PR TITLE
Replace --unstable with --unstable-ffi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: denoland/setup-deno@v1
       - name: Compile x86_64
         run: |
-          deno compile --unstable --allow-env --allow-run --allow-net --allow-read --allow-write --allow-ffi --target x86_64-apple-darwin music-rpc.ts
+          deno compile --allow-env --allow-run --allow-net --allow-read --allow-write --unstable-ffi --allow-ffi --target x86_64-apple-darwin music-rpc.ts
           mv music-rpc music-rpc-${{ steps.version.outputs.commit_sha }}-x86_64-apple-darwin
       - name: Upload x86_64
         uses: actions/upload-artifact@v4
@@ -27,7 +27,7 @@ jobs:
           path: music-rpc-${{ steps.version.outputs.commit_sha }}-x86_64-apple-darwin
       - name: Compile aarch64
         run: |
-          deno compile --unstable --allow-env --allow-run --allow-net --allow-read --allow-write --allow-ffi --target aarch64-apple-darwin music-rpc.ts
+          deno compile --allow-env --allow-run --allow-net --allow-read --allow-write --unstable-ffi --allow-ffi --target aarch64-apple-darwin music-rpc.ts
           mv music-rpc music-rpc-${{ steps.version.outputs.commit_sha }}-aarch64-apple-darwin
       - name: Upload aarch64
         uses: actions/upload-artifact@v4

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run --unstable --allow-env --allow-run --allow-net --allow-read --allow-write --allow-ffi
+#!/usr/bin/env deno run --allow-env --allow-run --allow-net --allow-read --allow-write --unstable-ffi --allow-ffi
 
 import type { Activity } from "https://deno.land/x/discord_rpc@0.3.2/mod.ts";
 import { Client } from "https://deno.land/x/discord_rpc@0.3.2/mod.ts";


### PR DESCRIPTION
> ⚠️  The `Deno.dlopen` API was used with `--unstable` flag. The `--unstable` flag is deprecated and will be removed in Deno 2.0. Use granular `--unstable-ffi` instead.
Learn more at: https://docs.deno.com/runtime/manual/tools/unstable_flags
