### PR TITLE
Enhance error handling and add artwork fallback to prevent freezes

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -108,12 +108,11 @@ async function _getTrackExtras(
     entity: "song",
     term: query,
   });
-  const resp = await fetch(
-    `https://itunes.apple.com/search?${params}`
-  );
+  const url = `https://itunes.apple.com/search?${params}`;
+  const resp = await fetch(url);
 
   if (!resp.ok) {
-    console.error("iTunes API error:", resp.statusText);
+    console.error("iTunes API error:", resp.statusText, url);
 
     return {
       artworkUrl: await _getMBArtwork(artist, song, album) ?? null,


### PR DESCRIPTION
This PR adds some basic error handling to the main loop to prevent the script from freezing. I was having issues for a while now where the script would freeze on a specific song and wouldn't update the activity until I restarted the script. 

After adding some logging to the requests, it seems sometimes the iTunes API request was failing for whatever reason (not sure if it's a request limit or something else):
```
Failed to fetch iTunes API: Service Unavailable
```

So I've added a catch method to the main loop to restart the function if it happens to fail. This has been working really well so far. I still have the errors in the log showing up, but the script correctly restarts and tries to fetch it again until it works.

Let me know what you think!