### PR TITLE
Add `--allow-import` to shebang

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run --allow-env --allow-run --allow-net --allow-read --allow-write --unstable-ffi --allow-ffi --unstable-kv
+#!/usr/bin/env deno run --allow-env --allow-run --allow-net --allow-read --allow-write --unstable-ffi --allow-ffi --unstable-kv --allow-import
 import type { Activity } from "https://deno.land/x/discord_rpc@0.3.2/mod.ts";
 import { Client } from "https://deno.land/x/discord_rpc@0.3.2/mod.ts";
 import type {} from "https://raw.githubusercontent.com/NextFire/jxa/v0.0.5/run/global.d.ts";


### PR DESCRIPTION
Running `music-rpc.ts` using launch agent fails with Deno 2 RC versions because of the new `--allow-import` permission.

```
$ deno -V
deno 2.0.0-rc.9
```

```
error: Requires import access to "win32.deno.dev:443", run again with the --allow-import flag
    at https://deno.land/x/namedpipe@0.1.2/deps.ts:1:21
```