### PR TITLE
Fix un-catched exception

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run --allow-env --allow-run --allow-net --allow-read --allow-write --allow-ffi --allow-hrtime --unstable-kv
+#!/usr/bin/env deno run --allow-env --allow-run --allow-net --allow-read --allow-write --allow-ffi --allow-import --unstable-kv
 import type { Activity } from "https://deno.land/x/discord_rpc@0.3.2/mod.ts";
 import { Client } from "https://deno.land/x/discord_rpc@0.3.2/mod.ts";
 import type {} from "https://raw.githubusercontent.com/NextFire/jxa/v0.0.5/run/global.d.ts";

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -32,6 +32,18 @@ class AppleMusicDiscordRPC {
     }
   }
 
+  tryCloseRPC(): void {
+    if (this.rpc.ipc) {
+      console.log("Attempting to close connection to Discord RPC");
+      try {
+        this.rpc.close();
+      } finally {
+        console.log("Connection to Discord RPC closed");
+        this.rpc.ipc = undefined;
+      }
+    }
+  }
+
   async setActivityLoop(): Promise<void> {
     try {
       await this.rpc.connect();
@@ -43,15 +55,7 @@ class AppleMusicDiscordRPC {
       }
     } finally {
       // Ensure the connection is properly closed
-      if (this.rpc.ipc) {
-        console.log("Attempting to close connection to Discord RPC");
-        try {
-          this.rpc.close();
-        } finally {
-          console.log("Connection to Discord RPC closed");
-          this.rpc.ipc = undefined;
-        }
-      }
+      this.tryCloseRPC();
     }
   }
 

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run --allow-env --allow-run --allow-net --allow-read --allow-write --allow-ffi --allow-import --unstable-kv
+#!/usr/bin/env deno run --allow-env --allow-run --allow-net --allow-read --allow-write --allow-ffi --allow-hrtime --unstable-kv
 import type { Activity } from "https://deno.land/x/discord_rpc@0.3.2/mod.ts";
 import { Client } from "https://deno.land/x/discord_rpc@0.3.2/mod.ts";
 import type {} from "https://raw.githubusercontent.com/NextFire/jxa/v0.0.5/run/global.d.ts";
@@ -44,9 +44,13 @@ class AppleMusicDiscordRPC {
     } finally {
       // Ensure the connection is properly closed
       if (this.rpc.ipc) {
-        console.log("Closing connection to Discord RPC");
-        this.rpc.close();
-        this.rpc.ipc = undefined;
+        console.log("Attempting to close connection to Discord RPC");
+        try {
+          this.rpc.close();
+        } finally {
+          console.log("Connection to Discord RPC closed");
+          this.rpc.ipc = undefined;
+        }
       }
     }
   }


### PR DESCRIPTION
Hi there! 
Awesome project!

I have started to have an issue a few weeks ago where Apple Music will stop being responsive to pause and skip buttons. I am not sure if this is because of this library, so I looked into it. 

I cannot consistently reproduce this issue, but the one time I could, I found an error in the logs at the same time:
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/846e2b06-7172-4777-85b8-8cc501cc8df5" />
```
Closing connection to Discord RPC
Error: (1000) Request has been terminated
Possible causes: the network is offline, Origin is not allowed by Access-Control-Allow-Origin, the page is being unloaded, etc.
    at DiscordIPC.#read (https://deno.land/x/discord_rpc@0.3.2/src/conn.ts:180:11)
    at eventLoopTick (ext:core/01_core.js:175:7)
    at async https://deno.land/x/discord_rpc@0.3.2/src/conn.ts:49:11
```

Looking into the code, it seems `this.rpc.close();` is trusted to not error and any error coming from it is not catched. So in this PR I added a `try` block around it. Even if this is not the root cause of my issue, it is still a good idea to catch any errors from this line of code.

~~While running this code locally, I also noticed that it complains about~~
```
[0m[1m[31merror[0m: unexpected argument '--allow-import' found

  tip: a similar argument exists: '--allow-hrtime'
  tip: to pass '--allow-import' as a value, use '-- --allow-import'

Usage: deno run [OPTIONS] [SCRIPT_ARG]...
```
~~so I followed the suggestion and used `--allow-hrtime` instead. If this is intended or my system is outdated feel free to let me know and I will revert this change.~~ (I had an outdated deno version)