### PR TITLE
Address Minimum Length Issue

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -178,18 +178,18 @@ class AppleMusicDiscordRPC {
     return version;
   }
 
-  static ensureStringLengthValid(value: string, maxLength = 128): string {
-    return (value.length < 2) ? this.padString(value) : this.truncateString(value, maxLength);
+  static ensureStringLengthValid(value: string, minLength = 2, maxLength = 128): string {
+    return (value.length < minLength) ? this.padString(value, minLength) : this.truncateString(value, maxLength);
   }
 
-  static truncateString(value: string, maxLength = 128): string {
+  static truncateString(value: string, maxLength: number): string {
     return value.length <= maxLength
       ? value
       : `${value.slice(0, maxLength - 3)}...`;
   }
 
-  static padString(value: string): string {
-    return ` ${value} `;
+  static padString(value: string, minLength: number): string {
+    return value.padEnd(minLength);
   }
 }
 

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -130,6 +130,7 @@ class AppleMusicDiscordRPC {
           }
         }
 
+       AppleMusicDiscordRPC.padInvalidPropsWithWhitespace(activity);
         await this.rpc.setActivity(activity);
         return Math.min(
           (delta ?? this.defaultTimeout) + 1000,
@@ -178,10 +179,23 @@ class AppleMusicDiscordRPC {
     return version;
   }
 
+  static padInvalidPropsWithWhitespace(activity: Activity) : void {
+    if (activity.details?.length < 2) {
+      activity.details = this.padString(activity.details);
+    }
+    if (activity.assets?.large_text?.length < 2) {
+      activity.assets.large_text = this.padString(activity.assets.large_text);
+    }
+  }
+
   static truncateString(value: string, maxLength = 128): string {
     return value.length <= maxLength
       ? value
       : `${value.slice(0, maxLength - 3)}...`;
+  }
+
+  static padString(value: string): string {
+    return ` ${value} `;
   }
 }
 

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -87,13 +87,13 @@ class AppleMusicDiscordRPC {
         const activity: Activity = {
           // @ts-ignore: "listening to" is allowed in recent Discord versions
           type: 2,
-          details: AppleMusicDiscordRPC.truncateString(props.name),
+          details: AppleMusicDiscordRPC.ensureStringLengthValid(props.name),
           timestamps: { start, end },
           assets: { large_image: "appicon" },
         };
 
         if (props.artist) {
-          activity.state = AppleMusicDiscordRPC.truncateString(props.artist);
+          activity.state = AppleMusicDiscordRPC.ensureStringLengthValid(props.artist);
         }
 
         if (props.album) {
@@ -102,7 +102,7 @@ class AppleMusicDiscordRPC {
 
           activity.assets = {
             large_image: infos.artworkUrl ?? "appicon",
-            large_text: AppleMusicDiscordRPC.truncateString(props.album),
+            large_text: AppleMusicDiscordRPC.ensureStringLengthValid(props.album),
           };
 
           const buttons = [];
@@ -130,7 +130,6 @@ class AppleMusicDiscordRPC {
           }
         }
 
-       AppleMusicDiscordRPC.padInvalidPropsWithWhitespace(activity);
         await this.rpc.setActivity(activity);
         return Math.min(
           (delta ?? this.defaultTimeout) + 1000,
@@ -179,13 +178,8 @@ class AppleMusicDiscordRPC {
     return version;
   }
 
-  static padInvalidPropsWithWhitespace(activity: Activity) : void {
-    if (activity.details?.length < 2) {
-      activity.details = this.padString(activity.details);
-    }
-    if (activity.assets?.large_text?.length < 2) {
-      activity.assets.large_text = this.padString(activity.assets.large_text);
-    }
+  static ensureStringLengthValid(value: string, maxLength = 128): string {
+    return (value.length < 2) ? this.padString(value) : this.truncateString(value, maxLength);
   }
 
   static truncateString(value: string, maxLength = 128): string {

--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -87,13 +87,15 @@ class AppleMusicDiscordRPC {
         const activity: Activity = {
           // @ts-ignore: "listening to" is allowed in recent Discord versions
           type: 2,
-          details: AppleMusicDiscordRPC.ensureStringLengthValid(props.name),
+          details: AppleMusicDiscordRPC.ensureValidStringLength(props.name),
           timestamps: { start, end },
           assets: { large_image: "appicon" },
         };
 
         if (props.artist) {
-          activity.state = AppleMusicDiscordRPC.ensureStringLengthValid(props.artist);
+          activity.state = AppleMusicDiscordRPC.ensureValidStringLength(
+            props.artist,
+          );
         }
 
         if (props.album) {
@@ -102,7 +104,9 @@ class AppleMusicDiscordRPC {
 
           activity.assets = {
             large_image: infos.artworkUrl ?? "appicon",
-            large_text: AppleMusicDiscordRPC.ensureStringLengthValid(props.album),
+            large_text: AppleMusicDiscordRPC.ensureValidStringLength(
+              props.album,
+            ),
           };
 
           const buttons = [];
@@ -178,18 +182,18 @@ class AppleMusicDiscordRPC {
     return version;
   }
 
-  static ensureStringLengthValid(value: string, minLength = 2, maxLength = 128): string {
-    return (value.length < minLength) ? this.padString(value, minLength) : this.truncateString(value, maxLength);
-  }
-
-  static truncateString(value: string, maxLength: number): string {
-    return value.length <= maxLength
-      ? value
-      : `${value.slice(0, maxLength - 3)}...`;
-  }
-
-  static padString(value: string, minLength: number): string {
-    return value.padEnd(minLength);
+  static ensureValidStringLength(
+    value: string,
+    minLength = 2,
+    maxLength = 128,
+  ): string {
+    if (value.length < minLength) {
+      return value.padEnd(minLength);
+    } else if (value.length > maxLength) {
+      return `${value.slice(0, maxLength - 3)}...`;
+    } else {
+      return value;
+    }
   }
 }
 


### PR DESCRIPTION
This addresses the issue I just made, #123.

It achieves this by making a method that pads the strings with whitespace, so that they meet the minimum length criteria.

For the previous behavior, see logs mentioned in the issue, with these changes it works as expected:

<img width="279" alt="Screenshot 2025-01-21 at 08 57 55" src="https://github.com/user-attachments/assets/2b86afc0-9a65-47ec-8795-c0fa48689ed5" />
<img width="277" alt="Screenshot 2025-01-21 at 08 59 07" src="https://github.com/user-attachments/assets/22959caa-c6ed-486c-b268-0c495fc035d9" />
