### PR TITLE
feat: artwork upload on catbox.moe

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Works with local tracks and Apple Music streaming service.
 - Presence is only enabled when actually playing something
 - Apple Music matching
   ([#5](https://github.com/NextFire/apple-music-discord-rpc/pull/5))
-- MusicBrainz artwork fallback
-  ([#66](https://github.com/NextFire/apple-music-discord-rpc/pull/66))
+- Local artwork upload to Catbox fallback
 
 <img width="230" height="47" alt="image" src="https://github.com/user-attachments/assets/2e168586-4202-46a3-a2d5-0e4e499ecdc6" />
 <img width="296" height="128" alt="image" src="https://github.com/user-attachments/assets/d5c01904-d43e-4f10-990d-2c75ff3acc61" />


### PR DESCRIPTION
- Upload local artwork on catbox.moe as a fallback
- It replaces musicbrainz lookup
- Refactored things a bit

Inspired by @yuimarudev's work (thanks!).

I opted for uploading the artworks to an external service, since they're small, non-sensitive files, and it also makes it easier for the user not to have to set up any cloudflared-like solution.

Fix #126 