### PR TITLE
Reduce Discord RPC polling churn

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -15,6 +15,13 @@ class AppleMusicDiscordRPC {
   static readonly KV_VERSION = 3;
 
   private startTime!: number;
+  private activityCleared = true;
+  private lastPresence?: {
+    trackId: string;
+    playerPosition: number;
+    observedAt: number;
+    expiresAt?: number;
+  };
 
   /**
    * @private Use `AppleMusicDiscordRPC.create()` instead.
@@ -35,7 +42,6 @@ class AppleMusicDiscordRPC {
       } catch (err) {
         console.error(err);
       }
-      console.log("Reconnecting in %dms", this.defaultTimeout);
       await sleep(this.defaultTimeout);
     }
   }
@@ -48,6 +54,8 @@ class AppleMusicDiscordRPC {
       } finally {
         console.log("Connection to Discord RPC closed");
         this.rpc.ipc = undefined;
+        this.activityCleared = true;
+        this.lastPresence = undefined;
       }
     }
   }
@@ -55,7 +63,6 @@ class AppleMusicDiscordRPC {
   async setActivityLoop(): Promise<void> {
     const discordRunning = await isDiscordRunning();
     if (!discordRunning) {
-      console.log("No Discord client is running");
       return;
     }
     try {
@@ -67,7 +74,6 @@ class AppleMusicDiscordRPC {
           Deno.exit(0);
         }
         const timeout = await this.setActivity();
-        console.log("Next setActivity in %dms", timeout);
         await sleep(timeout);
       }
     } finally {
@@ -77,42 +83,55 @@ class AppleMusicDiscordRPC {
   }
 
   async setActivity(): Promise<number> {
-    const musicRunning = await isMusicRunning(this.appName);
-    console.log("musicRunning:", musicRunning);
+    const musicStatus = await getMusicStatus(this.appName);
 
-    if (!musicRunning) {
-      await this.rpc.clearActivity();
+    if (!musicStatus.running) {
+      await this.clearActivityIfNeeded();
       return this.defaultTimeout;
     }
 
-    const state = await getMusicState(this.appName);
-    console.log("state:", state);
-
-    switch (state) {
+    switch (musicStatus.state) {
       case "playing": {
-        const { activity, delta } = await this.getPlayingActivity();
-        await this.rpc.setActivity(activity);
-        return Math.min(
-          (delta ?? this.defaultTimeout) + 1000,
+        const properties = musicStatus.properties;
+        if (!properties) {
+          await this.clearActivityIfNeeded();
+          return this.defaultTimeout;
+        }
+
+        if (this.shouldRefreshPlayingActivity(properties)) {
+          const { activity, expiresAt } = await this.getPlayingActivity(
+            properties,
+          );
+          await this.rpc.setActivity(activity);
+          this.activityCleared = false;
+          this.lastPresence = {
+            trackId: properties.persistentID,
+            playerPosition: properties.playerPosition,
+            observedAt: Date.now(),
+            expiresAt,
+          };
+        }
+
+        return AppleMusicDiscordRPC.getNextTimeout(
+          properties,
           this.defaultTimeout,
         );
       }
 
       case "paused":
       case "stopped": {
-        await this.rpc.clearActivity();
+        await this.clearActivityIfNeeded();
         return this.defaultTimeout;
       }
 
       default:
-        throw new Error(`Unknown state: ${state}`);
+        throw new Error(`Unknown state: ${musicStatus.state}`);
     }
   }
 
-  async getPlayingActivity(): Promise<{ activity: Activity; delta?: number }> {
-    const properties = await getMusicProperties(this.appName);
-    console.log("properties:", properties);
-
+  async getPlayingActivity(
+    properties: iTunesProperties,
+  ): Promise<{ activity: Activity; expiresAt?: number }> {
     let delta, start, end;
     if (properties.duration) {
       delta = (properties.duration - properties.playerPosition) * 1000;
@@ -136,9 +155,10 @@ class AppleMusicDiscordRPC {
       );
     }
 
+    let expiresAt;
     if (properties.album) {
       const extras = await this.cachedTrackExtras(properties);
-      console.log("extras:", extras);
+      expiresAt = extras.expiresAt;
 
       // @ts-expect-error: https://github.com/discord/discord-api-docs/pull/7674
       activity.details_url = extras.trackViewUrl;
@@ -170,7 +190,35 @@ class AppleMusicDiscordRPC {
       }
     }
 
-    return { activity, delta };
+    return { activity, expiresAt };
+  }
+
+  async clearActivityIfNeeded(): Promise<void> {
+    if (this.activityCleared) {
+      return;
+    }
+    await this.rpc.clearActivity();
+    this.activityCleared = true;
+    this.lastPresence = undefined;
+  }
+
+  shouldRefreshPlayingActivity(properties: iTunesProperties): boolean {
+    if (this.activityCleared || !this.lastPresence) {
+      return true;
+    }
+    if (this.lastPresence.trackId !== properties.persistentID) {
+      return true;
+    }
+    if (
+      this.lastPresence.expiresAt &&
+      this.lastPresence.expiresAt <= Date.now()
+    ) {
+      return true;
+    }
+
+    const elapsedSeconds = (Date.now() - this.lastPresence.observedAt) / 1000;
+    const expectedPosition = this.lastPresence.playerPosition + elapsedSeconds;
+    return Math.abs(properties.playerPosition - expectedPosition) > 5;
   }
 
   async cachedTrackExtras(properties: iTunesProperties): Promise<TrackExtras> {
@@ -216,6 +264,17 @@ class AppleMusicDiscordRPC {
       return value;
     }
   }
+
+  static getNextTimeout(
+    properties: Pick<iTunesProperties, "duration" | "playerPosition">,
+    defaultTimeout: number,
+  ): number {
+    if (!properties.duration) {
+      return defaultTimeout;
+    }
+    const delta = (properties.duration - properties.playerPosition) * 1000;
+    return Math.min(delta + 1000, defaultTimeout);
+  }
 }
 
 function sleep(ms: number): Promise<void> {
@@ -236,26 +295,31 @@ function isDiscordRunning(): Promise<boolean> {
   }, ["Discord", "Discord PTB", "Discord Canary"]);
 }
 
-function isMusicRunning(appName: iTunesAppName): Promise<boolean> {
+function getMusicStatus(appName: iTunesAppName): Promise<MusicStatus> {
   return run((appName: iTunesAppName) => {
-    return Application("System Events").processes[appName].exists();
-  }, appName);
-}
+    const systemEvents = Application("System Events");
+    if (!systemEvents.processes[appName].exists()) {
+      return { running: false };
+    }
 
-function getMusicState(appName: iTunesAppName): Promise<string> {
-  return run((appName: iTunesAppName) => {
     const music = Application(appName) as unknown as iTunes;
-    return music.playerState();
-  }, appName);
-}
+    const state = music.playerState();
+    if (state !== "playing") {
+      return { running: true, state };
+    }
 
-function getMusicProperties(appName: iTunesAppName): Promise<iTunesProperties> {
-  return run((appName: iTunesAppName) => {
-    const music = Application(appName) as unknown as iTunes;
-    return {
-      ...music.currentTrack().properties(),
-      playerPosition: music.playerPosition(),
-    };
+    try {
+      return {
+        running: true,
+        state,
+        properties: {
+          ...music.currentTrack().properties(),
+          playerPosition: music.playerPosition(),
+        },
+      };
+    } catch {
+      return { running: true, state };
+    }
   }, appName);
 }
 
@@ -417,6 +481,13 @@ async function litterboxUpload(
 
 //#region TypeScript
 type iTunesAppName = "iTunes" | "Music";
+type MusicState = "playing" | "paused" | "stopped";
+
+interface MusicStatus {
+  running: boolean;
+  state?: MusicState;
+  properties?: iTunesProperties;
+}
 
 interface iTunesProperties {
   persistentID: string;


### PR DESCRIPTION
## Summary
- collapse the Apple Music polling path into a single JXA status call per loop
- avoid re-sending identical Discord activity unless the track changes, playback position jumps, or temporary artwork expires
- remove hot-loop reconnect/state logging so the background service does less steady-state work

## Why
Issue #88 reports that the process RSS keeps growing over long runs even when heap snapshots do not show a clear JavaScript leak. This change reduces the two biggest sources of steady-state churn in the loop: repeated `osascript` invocations and repeated Discord RPC/log updates for the same track.

## Validation
- `deno fmt --check music-rpc.ts`
- `deno lint`
- `deno check --allow-import music-rpc.ts`
