### PR TITLE
fix: support Vesktop Discord client

### DIFF
--- a/music-rpc.ts
+++ b/music-rpc.ts
@@ -233,7 +233,7 @@ function isDiscordRunning(): Promise<boolean> {
     return clientNames.some((clientName) =>
       systemEvents.processes[clientName]?.exists()
     );
-  }, ["Discord", "Discord PTB", "Discord Canary"]);
+  }, ["Discord", "Discord PTB", "Discord Canary", "Vesktop"]);
 }
 
 function isMusicRunning(appName: iTunesAppName): Promise<boolean> {


### PR DESCRIPTION
The Discord client check added in c4138cbb9455c52676b07e497e4f9f519b4a7617 only looks for the official Discord process names before attempting the RPC connection. That regressed compatibility with third-party clients that expose the same IPC interface but run under different macOS process names.

Add Vesktop to the supported client process names so the RPC connection is attempted when Vesktop is running.